### PR TITLE
Fix "can't load package" error on OS X

### DIFF
--- a/gorun.go
+++ b/gorun.go
@@ -171,8 +171,7 @@ func RunFile(sourcefile string) (rundir, runfile string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	runfile = strings.Replace(sourcefile, "%", "%%", -1)
-	runfile = strings.Replace(runfile, string(filepath.Separator), "%", -1)
+	runfile = strings.Replace(sourcefile, string(filepath.Separator), "", -1)
 	runfile = filepath.Join(rundir, runfile)
 	runfile += ".gorun"
 	return rundir, runfile, nil


### PR DESCRIPTION
Without this fix, I get the following error:

```
$ gorun hello.go
can't load package: package main: invalid input file name "%Users%mlafeldt%hello.go.gorun.54808.go"
error: failed to run go: exit status 1
```

In my case, the generated source file is written to `$TMPDIR/gorun-mbp-mlafeldt.local-502/darwin_amd64/`.

With this change, the resulting file (`Usersmlafeldthello.go.gorun`) compiles just fine:

```
$ gorun hello.go
Hello world!
```