### PR TITLE
Fix filename compatibility with Go 1.9 and later

### DIFF
--- a/gorun.go
+++ b/gorun.go
@@ -172,6 +172,7 @@ func RunFile(sourcefile string) (rundir, runfile string, err error) {
 		return "", "", err
 	}
 	runfile = strings.Replace(sourcefile, "%", "%%", -1)
+	runfile = strings.Replace(runfile, string(filepath.Separator), "ROOT%", 1)
 	runfile = strings.Replace(runfile, string(filepath.Separator), "%", -1)
 	runfile = filepath.Join(rundir, runfile)
 	runfile += ".gorun"


### PR DESCRIPTION
In order to fix a potential security issue, the tools in go 1.9 and
later restrict the filenames that are accepted as input; starting with
a '%' is now forbidden.

Change the first '/' to 'ROOT%' instead to comply with the new rules.

Suggested-by: Vern Sun <s5unty@gmail.com>
Signed-off-by: George Dunlap <george.dunlap@citrix.com>