### PR TITLE
Fixed argument parsing to make use of go1.11 update on go run

### DIFF
--- a/gorun.go
+++ b/gorun.go
@@ -40,6 +40,10 @@ func main() {
 	args := os.Args[1:]
 
 	if len(args) == 0 {
+		args = append(args, ".")
+	}
+
+	if args[0] == "-h" || args[0] == "help" || args[0] == "-help" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(os.Stderr, "usage: gorun <source file> [...]")
 		os.Exit(1)
 	}


### PR DESCRIPTION
As of go 1.11, it's possible to run Go projects within the similar behavior that `go build` is giving.

From: https://golang.org/doc/go1.11

> ## Run
>
> The go run command now allows a single import path, a directory name or a pattern matching a single package. This allows go run pkg or go run dir, most importantly go run . 

This means that running `go run .` allows executing code within the same directory.

I have tested the behavior on `gorun`, and it's working normally.

What I'm suggesting is, if we run `gorun` with no arguments, it will be nice to run code within the current directory instead.

I reserved gorun help functionality with Go naming convention, while keeping POSIX conventions too for help message.

This resolves: #9, as well as making use of this awesome Go addition!

Best Regards,
Mazin


