### PR TITLE
Update for go 1.16, minimum required go version to build is 1.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Build
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [1.11.x, 1.16.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: go build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.11.x, 1.16.x]
+        go-version: [1.12.x, 1.16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/erning/gorun
 
-go 1.11
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/erning/gorun
+
+go 1.11

--- a/gorun.go
+++ b/gorun.go
@@ -50,11 +50,11 @@ func main() {
 
 	err := Run(args)
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "error: "+err.Error())
+		fmt.Fprintln(os.Stderr, "error: "+err.Error())
 		os.Exit(1)
 	}
-
-	panic("unreachable")
+	fmt.Fprintln(os.Stderr, "An uncaught error has occurred.")
+	os.Exit(1)
 }
 
 // Run compiles and links the Go source file on args[0] and
@@ -332,7 +332,6 @@ func RunBaseDir() (rundir string, err error) {
 		i++
 		prefixi = prefix + "-" + strconv.FormatUint(i, 10)
 	}
-	panic("unreachable")
 }
 
 const CleanFileDelay = time.Hour * 24 * 7
@@ -377,7 +376,9 @@ func CleanDir(runBaseDir string, now time.Time) error {
 	return nil
 }
 
+/*
 // TheChar returns the magic architecture char.
+// We should find out if we need this or not.
 func TheChar() string {
 	switch runtime.GOARCH {
 	case "386":
@@ -389,3 +390,4 @@ func TheChar() string {
 	}
 	panic("unknown GOARCH: " + runtime.GOARCH)
 }
+*/

--- a/gorun.go
+++ b/gorun.go
@@ -140,7 +140,7 @@ func getSection(content []byte, sectionName string) (section []byte) {
 }
 
 func writeFileFromComments(content []byte, sectionName string, file string) (written bool, err error) {
-	// Write a go.mod file from inside the comments
+	// Write go.mod and go.sum files from inside the comments
 	section := getSection(content, sectionName)
 	if len(section) > 0 {
 		err = ioutil.WriteFile(file, section, 0600)
@@ -181,7 +181,6 @@ func Compile(sourcefile, runFile string, runCmdDir string) (err error) {
 		return
 	}
 
-	// TODO as go.mod
 	// Write a go.sum file from inside the comments
 	sumFile := runCmdDir + "go.sum"
 	os.Remove(sumFile)

--- a/gorun.go
+++ b/gorun.go
@@ -40,6 +40,10 @@ func main() {
 	args := os.Args[1:]
 
 	if len(args) == 0 {
+		args = append(args, ".")
+	}
+
+	if args[0] == "-h" || args[0] == "help" || args[0] == "-help" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(os.Stderr, "usage: gorun <source file> [...]")
 		os.Exit(1)
 	}

--- a/gorun.go
+++ b/gorun.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	if args[0] == "-h" || args[0] == "help" || args[0] == "-help" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(os.Stderr, "usage: gorun <source file> [...]")
+		fmt.Fprintln(os.Stderr, "usage: gorun <source file> [...]")
 		os.Exit(1)
 	}
 

--- a/syscall.go
+++ b/syscall.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!freebsd
 
 package main
 


### PR DESCRIPTION
This will merge #17 and make the following changes.

- Check more errors.
- Clean up comments that aren't needed.
- Add go.mod file.
- Add GitHub actions for automating builds, currently for testing purposes only.
- Replaced some panic statements to make them slightly more descriptive.
- Minimum required version of go is 1.12, builds will fail on anything earlier.
- Build properly on darwin and freebsd.

We should probably determine if the function `TheChar()` is needed. I've placed comments around this function, go will happily build gorun without it.