### PR TITLE
Format for go 1.17 go:build format.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.16.x]
+        go-version: [1.12.x, 1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/syscall.go
+++ b/syscall.go
@@ -1,3 +1,4 @@
+//go:build !darwin && !freebsd && !netbsd
 // +build !darwin,!freebsd,!netbsd
 
 package main

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package main

--- a/syscall_freebsd.go
+++ b/syscall_freebsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd
 // +build freebsd
 
 package main

--- a/syscall_netbsd.go
+++ b/syscall_netbsd.go
@@ -1,3 +1,4 @@
+//go:build netbsd
 // +build netbsd
 
 package main


### PR DESCRIPTION
Changes in go 1.17 have introduced the //go:build line. Gofmt synchronizes these with the old //+build format. Both should interoperate together.