### PR TITLE
Updates to remove ineffectual error assignment, and upgrade GitHub action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,16 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.17.x]
+        go-version: [1.12.x, 1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build
       run: go build

--- a/gorun.go
+++ b/gorun.go
@@ -163,7 +163,7 @@ func Compile(sourcefile, runFile string, runCmdDir string) (err error) {
 		return err
 	}
 	var writtenSource bool
-	content, err := ioutil.ReadFile(sourcefile)
+	content, _ := ioutil.ReadFile(sourcefile)
 	if len(content) > 2 && content[0] == '#' && content[1] == '!' {
 		content[0] = '/'
 		content[1] = '/'


### PR DESCRIPTION
This PR will remove an ineffectual error assignment to an error variable that was never checked. Additionally, it updates the GitHub action for building to use V3 of setup-go and checkout, and will also build against Go 1.20.x.