### PR TITLE
Update GitHub action to build against all supported operating systems.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,18 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.20.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+        go-version: ['1.12.x', 'stable']
+        os: ['linux', 'darwin', 'freebsd', 'netbsd']
+    runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Build
+      env:
+        GOOS: ${{ matrix.os }}
       run: go build


### PR DESCRIPTION
The GitHub action will now test builds against linux, freebad, netbsd, and darwin. More operating systems can be added to the matrix os variable, if desired. The latest stable version of Go will also be used for testing, rather than explicitly defining 1.20.x, this should help in the future when Go is updated.